### PR TITLE
Enhance facade, contemplating https://github.com/pouchdb/pouchdb/issues/5508

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ enablePlugins(ScalaJSPlugin)
 
 name := "pouchdb"
 
-version := "2016.4.0"
+version := "2016.8.0-SNAPSHOT"
 
 organization := "com.github.chandu0101.scalajs"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.8")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.11")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % "0.1.1"

--- a/src/main/scala/chandu0101/pouchdb/PouchDB.scala
+++ b/src/main/scala/chandu0101/pouchdb/PouchDB.scala
@@ -7,13 +7,13 @@ import scala.scalajs.js.Dynamic.{literal => json}
 import scala.scalajs.js.annotation.{ScalaJSDefined, JSName}
 import scala.scalajs.js.{Array => JArray, Promise, UndefOr, undefined}
 
-@js.native
+@ScalaJSDefined
 trait PouchDBAjaxOptions extends js.Object {
-  val timeout: UndefOr[Double] = js.native
-  val headers: UndefOr[js.Dictionary[js.Any]] = js.native
-  val withCredentials: UndefOr[Boolean] = js.native
-  val skip_setup: UndefOr[Boolean] = js.native
-  val cache: UndefOr[Boolean] = js.native
+  val timeout: UndefOr[Double]
+  val headers: UndefOr[js.Dictionary[js.Any]]
+  val withCredentials: UndefOr[Boolean]
+  val skip_setup: UndefOr[Boolean]
+  val cache: UndefOr[Boolean]
 }
 
 object PouchDBAjaxOptions {
@@ -24,10 +24,10 @@ object PouchDBAjaxOptions {
       skip_setup = skip_setup, cache = cache).asInstanceOf[PouchDBAjaxOptions]
 }
 
-@js.native
+@ScalaJSDefined
 trait PouchDBAuthOptions extends js.Object {
-  val username: UndefOr[String] = js.native
-  val password: UndefOr[String] = js.native
+  val username: UndefOr[String]
+  val password: UndefOr[String]
 }
 
 object PouchDBAuthOptions {
@@ -36,15 +36,15 @@ object PouchDBAuthOptions {
 }
 
 
-@js.native
+@ScalaJSDefined
 trait PouchDBOptions extends js.Object {
-  val name: UndefOr[String] = js.native
-  val adapter: UndefOr[String] = js.native
-  val revs_limit: UndefOr[Int] = js.native
-  val ajax: UndefOr[PouchDBAjaxOptions] = js.native
-  val auth: UndefOr[PouchDBAuthOptions] = js.native
-  val db: UndefOr[js.Any] = js.native
-  val auto_compaction: UndefOr[Boolean] = js.native
+  val name: UndefOr[String]
+  val adapter: UndefOr[String]
+  val revs_limit: UndefOr[Int]
+  val ajax: UndefOr[PouchDBAjaxOptions]
+  val auth: UndefOr[PouchDBAuthOptions]
+  val db: UndefOr[js.Any]
+  val auto_compaction: UndefOr[Boolean]
 }
 
 object PouchDBOptions {
@@ -55,9 +55,9 @@ object PouchDBOptions {
       db = db, auto_compaction = auto_compaction).asInstanceOf[PouchDBOptions]
 }
 
-@js.native
+@ScalaJSDefined
 trait PouchDBDestroyOptions extends js.Object {
-  val ajax: UndefOr[PouchDBAjaxOptions] = js.native
+  val ajax: UndefOr[PouchDBAjaxOptions]
 }
 
 object PouchDBDestroyOptions {
@@ -65,20 +65,20 @@ object PouchDBDestroyOptions {
     js.Dynamic.literal(ajax = ajax).asInstanceOf[PouchDBDestroyOptions]
 }
 
-@js.native
+@ScalaJSDefined
 trait PouchDBAllDocsOptions extends js.Object {
-  val include_docs: UndefOr[Boolean] = js.native
-  val startkey: UndefOr[String] = js.native
-  val endkey: UndefOr[String] = js.native
-  val inclusive_end: UndefOr[Boolean] = js.native
-  val limit: UndefOr[Int] = js.native
-  val skip: UndefOr[Int] = js.native
-  val descending: UndefOr[Boolean] = js.native
-  val conflicts: UndefOr[Boolean] = js.native
-  val attachments: UndefOr[Boolean] = js.native
-  val binary: UndefOr[Boolean] = js.native
-  val key: UndefOr[String] = js.native
-  val keys: UndefOr[js.Array[String]] = js.native
+  val include_docs: UndefOr[Boolean]
+  val startkey: UndefOr[String]
+  val endkey: UndefOr[String]
+  val inclusive_end: UndefOr[Boolean]
+  val limit: UndefOr[Int]
+  val skip: UndefOr[Int]
+  val descending: UndefOr[Boolean]
+  val conflicts: UndefOr[Boolean]
+  val attachments: UndefOr[Boolean]
+  val binary: UndefOr[Boolean]
+  val key: UndefOr[String]
+  val keys: UndefOr[js.Array[String]]
 }
 
 object PouchDBAllDocsOptions {
@@ -109,33 +109,33 @@ trait ChangesEventEmitter extends EventEmitter {
   def cancel(): Unit = js.native
 }
 
-@js.native
+@ScalaJSDefined
 trait PouchDBError extends js.Object {
-  val status: Int = js.native
-  val name: String = js.native
-  val message: String = js.native
+  val status: Int
+  val name: String
+  val message: String
 }
 
-@js.native
+@ScalaJSDefined
 trait EventInfo extends js.Object {
-  val doc_write_failures: Int = js.native
-  val docs_read: Int = js.native
-  val docs_written: Int = js.native
-  val errors: js.Array[PouchDBError] = js.native
-  val last_seq: Int = js.native
-  val ok: Boolean = js.native
-  val start_time: String = js.native
+  val doc_write_failures: Int
+  val docs_read: Int
+  val docs_written: Int
+  val errors: js.Array[PouchDBError]
+  val last_seq: Int
+  val ok: Boolean
+  val start_time: String
 }
 
-@js.native
+@ScalaJSDefined
 trait OnChangeInfo extends EventInfo {
-  val docs: js.Array[js.Object] = js.native
+  val docs: js.Array[js.Object]
 }
 
-@js.native
+@ScalaJSDefined
 trait OnCompleteInfo extends EventInfo {
-  val end_time: String = js.native
-  val status: String = js.native
+  val end_time: String
+  val status: String
 }
 
 object ChangesEventEmitter {
@@ -153,25 +153,25 @@ object ChangesEventEmitter {
 
 }
 
-@js.native
+@ScalaJSDefined
 trait PouchDBChangesOptions extends js.Object {
-  val live: UndefOr[Boolean] = js.native
-  val include_docs: UndefOr[Boolean] = js.native
-  val conflicts: UndefOr[Boolean] = js.native
-  val attachments: UndefOr[Boolean] = js.native
-  val binary: UndefOr[Boolean] = js.native
-  val descending: UndefOr[Boolean] = js.native
-  val since: UndefOr[String] = js.native
-  val limit: UndefOr[Int] = js.native
-  val timeout: UndefOr[Int] = js.native
-  val heartbeat: UndefOr[Int] = js.native
-  val filter: UndefOr[js.Function] = js.native
-  val doc_ids: UndefOr[js.Array[String]] = js.native
-  val query_params: UndefOr[js.Dynamic] = js.native
-  val view: UndefOr[js.Function] = js.native
-  val return_docs: UndefOr[Boolean] = js.native
-  val batch_size: UndefOr[Int] = js.native
-  val style: UndefOr[String] = js.native
+  val live: UndefOr[Boolean]
+  val include_docs: UndefOr[Boolean]
+  val conflicts: UndefOr[Boolean]
+  val attachments: UndefOr[Boolean]
+  val binary: UndefOr[Boolean]
+  val descending: UndefOr[Boolean]
+  val since: UndefOr[String]
+  val limit: UndefOr[Int]
+  val timeout: UndefOr[Int]
+  val heartbeat: UndefOr[Int]
+  val filter: UndefOr[js.Function]
+  val doc_ids: UndefOr[js.Array[String]]
+  val query_params: UndefOr[js.Dynamic]
+  val view: UndefOr[js.Function]
+  val return_docs: UndefOr[Boolean]
+  val batch_size: UndefOr[Int]
+  val style: UndefOr[String]
 }
 
 object PouchDBChangesOptions {
@@ -187,20 +187,20 @@ object PouchDBChangesOptions {
       batch_size = batch_size, style = style).asInstanceOf[PouchDBChangesOptions]
 }
 
-@js.native
+@ScalaJSDefined
 trait PouchDBReplicateOptions extends js.Object {
-  val live: UndefOr[Boolean] = js.native
-  val retry: UndefOr[Boolean] = js.native
-  val filter: UndefOr[js.Function] = js.native
-  val doc_ids: UndefOr[js.Array[String]] = js.native
-  val query_params: UndefOr[js.Object] = js.native
-  val view: UndefOr[js.Function] = js.native
-  val since: UndefOr[String] = js.native
-  val heartbeat: UndefOr[Int] = js.native
-  val timeout: UndefOr[Int] = js.native
-  val batch_size: UndefOr[Int] = js.native
-  val batches_limit: UndefOr[Int] = js.native
-  val back_off_function: UndefOr[js.Function] = js.native
+  val live: UndefOr[Boolean]
+  val retry: UndefOr[Boolean]
+  val filter: UndefOr[js.Function]
+  val doc_ids: UndefOr[js.Array[String]]
+  val query_params: UndefOr[js.Object]
+  val view: UndefOr[js.Function]
+  val since: UndefOr[String]
+  val heartbeat: UndefOr[Int]
+  val timeout: UndefOr[Int]
+  val batch_size: UndefOr[Int]
+  val batches_limit: UndefOr[Int]
+  val back_off_function: UndefOr[js.Function]
 }
 
 object PouchDBReplicateOptions {
@@ -221,22 +221,22 @@ trait Replicate extends js.Object {
   def from(remoteDB: PouchDB | String, options: PouchDBReplicateOptions = ???): ChangesEventEmitter = js.native
 }
 
-@js.native
+@ScalaJSDefined
 trait PouchDBQueryOptions extends js.Object {
-  val fun: UndefOr[js.Function] = js.native
-  val reduce: UndefOr[js.Function | String] = js.native
-  val include_docs: UndefOr[Boolean] = js.native
-  val startkey: UndefOr[String] = js.native
-  val endkey: UndefOr[String] = js.native
-  val inclusive_end: UndefOr[Boolean] = js.native
-  val limit: UndefOr[Int] = js.native
-  val skip: UndefOr[Int] = js.native
-  val descending: UndefOr[Boolean] = js.native
-  val key: UndefOr[String] = js.native
-  val keys: UndefOr[js.Array[String]] = js.native
-  val group: UndefOr[Boolean] = js.native
-  val group_level: UndefOr[Int] = js.native
-  val stale: UndefOr[String] = js.native
+  val fun: UndefOr[js.Function]
+  val reduce: UndefOr[js.Function | String]
+  val include_docs: UndefOr[Boolean]
+  val startkey: UndefOr[String]
+  val endkey: UndefOr[String]
+  val inclusive_end: UndefOr[Boolean]
+  val limit: UndefOr[Int]
+  val skip: UndefOr[Int]
+  val descending: UndefOr[Boolean]
+  val key: UndefOr[String]
+  val keys: UndefOr[js.Array[String]]
+  val group: UndefOr[Boolean]
+  val group_level: UndefOr[Int]
+  val stale: UndefOr[String]
 }
 
 object PouchDBQueryOptions {
@@ -259,15 +259,15 @@ trait PouchDBDebug extends js.Object {
   def disable(): Unit = js.native
 }
 
-@js.native
-class PouchDBGetOptions extends js.Object {
-  val rev: UndefOr[String] = js.native
-  val revs: UndefOr[Boolean] = js.native
-  val revs_info: UndefOr[Boolean] = js.native
-  val open_revs: UndefOr[js.Dynamic] = js.native
-  val conflicts: UndefOr[Boolean] = js.native
-  val attachments: UndefOr[Boolean] = js.native
-  val ajax: UndefOr[PouchDBAjaxOptions] = js.native
+@ScalaJSDefined
+trait PouchDBGetOptions extends js.Object {
+  val rev: UndefOr[String]
+  val revs: UndefOr[Boolean]
+  val revs_info: UndefOr[Boolean]
+  val open_revs: UndefOr[js.Dynamic]
+  val conflicts: UndefOr[Boolean]
+  val attachments: UndefOr[Boolean]
+  val ajax: UndefOr[PouchDBAjaxOptions]
 }
 
 object PouchDBGetOptions {
@@ -303,9 +303,9 @@ trait PouchDBEntity extends js.Object {
   val _rev: String
 }
 
-@js.native
+@ScalaJSDefined
 trait PouchDBCompactOptions extends js.Object {
-  val interval: UndefOr[Int] = js.native
+  val interval: UndefOr[Int]
 }
 
 object PouchDBCompactOptions {
@@ -313,12 +313,12 @@ object PouchDBCompactOptions {
     js.Dynamic.literal(interval = interval).asInstanceOf[PouchDBCompactOptions]
 }
 
-@js.native
+@ScalaJSDefined
 trait PouchDBBulkGetOptions extends js.Object {
-  val docs: js.Array[js.Object] = js.native
-  val revs: UndefOr[Boolean] = js.native
-  val attachments: UndefOr[Boolean] = js.native
-  val binary: UndefOr[Boolean] = js.native
+  val docs: js.Array[js.Object]
+  val revs: UndefOr[Boolean]
+  val attachments: UndefOr[Boolean]
+  val binary: UndefOr[Boolean]
 }
 
 object PouchDBBulkGetOptions {
@@ -329,7 +329,7 @@ object PouchDBBulkGetOptions {
 
 @js.native
 @JSName("PouchDB")
-class PouchDB(name: String = ???, options: PouchDBOptions | js.Dynamic | js.Object | js.Dictionary[Any] = ???) extends js.Object with PouchDBFindPlugin {
+class PouchDB(name: String = ???, options: PouchDBOptions = ???) extends js.Object with PouchDBFindPlugin {
 
   var _db_name: String = js.native
 

--- a/src/main/scala/chandu0101/pouchdb/PouchDB.scala
+++ b/src/main/scala/chandu0101/pouchdb/PouchDB.scala
@@ -327,6 +327,17 @@ object PouchDBBulkGetOptions {
     js.Dynamic.literal(docs = docs, revs = revs, attachments = attachments, binary = binary).asInstanceOf[PouchDBBulkGetOptions]
 }
 
+@ScalaJSDefined
+trait PouchDBMapReduce extends js.Object {
+  val map: js.Function0[Unit]
+  val reduce: js.Function0[Unit]
+}
+
+object PouchDBMapReduce {
+  def apply(map: js.Function0[Unit], reduce: js.Function0[Unit]): PouchDBMapReduce =
+    js.Dynamic.literal(map = map, reduce = reduce).asInstanceOf[PouchDBMapReduce]
+}
+
 @js.native
 @JSName("PouchDB")
 class PouchDB(name: String = ???, options: PouchDBOptions = ???) extends js.Object with PouchDBFindPlugin {
@@ -365,7 +376,7 @@ class PouchDB(name: String = ???, options: PouchDBOptions = ???) extends js.Obje
 
   def removeAttachment(docId: String, attachmentId: String, rev: String): Promise[js.Dynamic] = js.native
 
-  def query(fun: js.Function, options: PouchDBQueryOptions = ???): Promise[js.Dynamic] = js.native
+  def query(fun: PouchDBMapReduce | js.Function0[Unit] | String, options: PouchDBQueryOptions = ???): Promise[js.Dynamic] = js.native
 
   def viewCleanup(): Promise[js.Dynamic] = js.native
 

--- a/src/main/scala/chandu0101/pouchdb/PouchDB.scala
+++ b/src/main/scala/chandu0101/pouchdb/PouchDB.scala
@@ -100,8 +100,8 @@ trait PouchDBAllDocsResponse extends js.Object {
 
 @js.native
 trait EventEmitter extends js.Object {
-  def on(event: String, listener: js.Function0[Unit]): this.type = js.native
-  def on[A](event: String, listener: js.Function1[A, Unit]): this.type = js.native
+  def on(event: String, listener: js.Function0[Any]): this.type = js.native
+  def on[A](event: String, listener: js.Function1[A, Any]): this.type = js.native
 }
 
 @js.native
@@ -141,14 +141,14 @@ trait OnCompleteInfo extends EventInfo {
 object ChangesEventEmitter {
 
   implicit class ChangesEventEmitterEvents(val self: ChangesEventEmitter) extends AnyVal {
-    def onChange(listener: js.Function1[OnChangeInfo, Unit]): self.type = self.on("change", listener)
-    def onComplete(listener: js.Function1[OnCompleteInfo, Unit]): self.type = self.on("complete", listener)
-    def onError(listener: js.Function1[PouchDBError, Unit]): self.type = self.on("error", listener)
-    def onDenied(listener: js.Function1[PouchDBError, Unit]): self.type = self.on("denied", listener)
-    def onPaused(listener: js.Function1[UndefOr[PouchDBError], Unit]): self.type = self.on("paused", listener)
-    def onActive(listener: js.Function0[Unit]): self.type = self.on("active", listener)
-    def onCreated(listener: js.Function1[String, Unit]): self.type = self.on("created", listener)
-    def onDestroyed(listener: js.Function1[String, Unit]): self.type = self.on("destroyed", listener)
+    def onChange(listener: js.Function1[OnChangeInfo, Any]): self.type = self.on("change", listener)
+    def onComplete(listener: js.Function1[OnCompleteInfo, Any]): self.type = self.on("complete", listener)
+    def onError(listener: js.Function1[PouchDBError, Any]): self.type = self.on("error", listener)
+    def onDenied(listener: js.Function1[PouchDBError, Any]): self.type = self.on("denied", listener)
+    def onPaused(listener: js.Function1[UndefOr[PouchDBError], Any]): self.type = self.on("paused", listener)
+    def onActive(listener: js.Function0[Any]): self.type = self.on("active", listener)
+    def onCreated(listener: js.Function1[String, Any]): self.type = self.on("created", listener)
+    def onDestroyed(listener: js.Function1[String, Any]): self.type = self.on("destroyed", listener)
   }
 
 }

--- a/src/main/scala/chandu0101/pouchdb/PouchDB.scala
+++ b/src/main/scala/chandu0101/pouchdb/PouchDB.scala
@@ -7,168 +7,276 @@ import scala.scalajs.js.Dynamic.{literal => json}
 import scala.scalajs.js.annotation.{ScalaJSDefined, JSName}
 import scala.scalajs.js.{Array => JArray, Promise, UndefOr, undefined}
 
-@ScalaJSDefined
-class PouchDBAjaxOptions(val timeout: UndefOr[Double] = undefined,
-                         val headers: UndefOr[js.Dictionary[js.Any]] = undefined,
-                         val withCredentials: UndefOr[Boolean] = undefined,
-                         val skip_setup: UndefOr[Boolean] = undefined,
-                         val cache: UndefOr[Boolean] = undefined) extends js.Object
+@js.native
+trait PouchDBAjaxOptions extends js.Object {
+  val timeout: UndefOr[Double] = js.native
+  val headers: UndefOr[js.Dictionary[js.Any]] = js.native
+  val withCredentials: UndefOr[Boolean] = js.native
+  val skip_setup: UndefOr[Boolean] = js.native
+  val cache: UndefOr[Boolean] = js.native
+}
+
+object PouchDBAjaxOptions {
+  def apply(timeout: UndefOr[Double] = undefined, headers: UndefOr[js.Dictionary[js.Any]] = undefined,
+            withCredentials: UndefOr[Boolean] = undefined, skip_setup: UndefOr[Boolean] = undefined,
+            cache: UndefOr[Boolean] = undefined): PouchDBAjaxOptions =
+    js.Dynamic.literal(timeout = timeout, headers = headers, withCredentials = withCredentials,
+      skip_setup = skip_setup, cache = cache).asInstanceOf[PouchDBAjaxOptions]
+}
+
+@js.native
+trait PouchDBAuthOptions extends js.Object {
+  val username: UndefOr[String] = js.native
+  val password: UndefOr[String] = js.native
+}
+
+object PouchDBAuthOptions {
+  def apply(username: UndefOr[String] = undefined, password: UndefOr[String] = undefined): PouchDBAuthOptions =
+    js.Dynamic.literal(username = username, password = password).asInstanceOf[PouchDBAuthOptions]
+}
 
 
-@ScalaJSDefined
-class PouchDBAuthOptions(val username: UndefOr[String] = undefined, val password: UndefOr[String] = undefined) extends js.Object
+@js.native
+trait PouchDBOptions extends js.Object {
+  val name: UndefOr[String] = js.native
+  val adapter: UndefOr[String] = js.native
+  val revs_limit: UndefOr[Int] = js.native
+  val ajax: UndefOr[PouchDBAjaxOptions] = js.native
+  val auth: UndefOr[PouchDBAuthOptions] = js.native
+  val db: UndefOr[js.Any] = js.native
+  val auto_compaction: UndefOr[Boolean] = js.native
+}
 
-@ScalaJSDefined
-class PouchDBOptions(val name: UndefOr[String] = undefined,
-                     val adapter: UndefOr[String] = undefined,
-                     val revs_limit: UndefOr[Int] = undefined,
-                     val ajax: UndefOr[PouchDBAjaxOptions] = undefined,
-                     val auth: UndefOr[PouchDBAuthOptions] = undefined,
-                     val db: UndefOr[js.Any] = undefined,
-                     val auto_compaction: UndefOr[Boolean] = undefined) extends js.Object
+object PouchDBOptions {
+  def apply(name: UndefOr[String] = undefined, adapter: UndefOr[String] = undefined, revs_limit: UndefOr[Int] = undefined,
+            ajax: UndefOr[PouchDBAjaxOptions] = undefined, auth: UndefOr[PouchDBAuthOptions] = undefined,
+            db: UndefOr[js.Any] = undefined, auto_compaction: UndefOr[Boolean] = undefined): PouchDBOptions =
+    js.Dynamic.literal(name = name, adapter = adapter, revs_limit = revs_limit, ajax = ajax, auth = auth,
+      db = db, auto_compaction = auto_compaction).asInstanceOf[PouchDBOptions]
+}
 
-@ScalaJSDefined
-class PouchDBDestroyOptions(val ajax: UndefOr[PouchDBAjaxOptions] = undefined) extends js.Object
+@js.native
+trait PouchDBDestroyOptions extends js.Object {
+  val ajax: UndefOr[PouchDBAjaxOptions] = js.native
+}
 
+object PouchDBDestroyOptions {
+  def apply(ajax: UndefOr[PouchDBAjaxOptions] = undefined): PouchDBDestroyOptions =
+    js.Dynamic.literal(ajax = ajax).asInstanceOf[PouchDBDestroyOptions]
+}
 
-@ScalaJSDefined
-class PouchDBAllDocsOptions(val include_docs: UndefOr[Boolean] = undefined,
-                            val startkey: UndefOr[String] = undefined,
-                            val endkey: UndefOr[String] = undefined,
-                            val inclusive_end: UndefOr[Boolean] = undefined,
-                            val limit: UndefOr[Int] = undefined,
-                            val skip: UndefOr[Int] = undefined,
-                            val descending: UndefOr[Boolean] = undefined,
-                            val conflicts: UndefOr[Boolean] = undefined,
-                            val attachments: UndefOr[Boolean] = undefined,
-                            val binary: UndefOr[Boolean] = undefined,
-                            val key: UndefOr[String] = undefined,
-                            val keys: UndefOr[js.Array[String]] = undefined) extends js.Object
+@js.native
+trait PouchDBAllDocsOptions extends js.Object {
+  val include_docs: UndefOr[Boolean] = js.native
+  val startkey: UndefOr[String] = js.native
+  val endkey: UndefOr[String] = js.native
+  val inclusive_end: UndefOr[Boolean] = js.native
+  val limit: UndefOr[Int] = js.native
+  val skip: UndefOr[Int] = js.native
+  val descending: UndefOr[Boolean] = js.native
+  val conflicts: UndefOr[Boolean] = js.native
+  val attachments: UndefOr[Boolean] = js.native
+  val binary: UndefOr[Boolean] = js.native
+  val key: UndefOr[String] = js.native
+  val keys: UndefOr[js.Array[String]] = js.native
+}
+
+object PouchDBAllDocsOptions {
+  def apply(include_docs: UndefOr[Boolean] = undefined, startkey: UndefOr[String] = undefined, endkey: UndefOr[String] = undefined,
+            inclusive_end: UndefOr[Boolean] = undefined, limit: UndefOr[Int] = undefined, skip: UndefOr[Int] = undefined,
+            descending: UndefOr[Boolean] = undefined, conflicts: UndefOr[Boolean] = undefined, attachments: UndefOr[Boolean] = undefined,
+            binary: UndefOr[Boolean] = undefined, key: UndefOr[String] = undefined, keys: UndefOr[js.Array[String]] = undefined): PouchDBAllDocsOptions =
+    js.Dynamic.literal(include_docs = include_docs, startkey = startkey, endkey = endkey, inclusive_end = inclusive_end,
+      limit = limit, skip = skip, descending = descending, conflicts = conflicts, attachments = attachments, binary = binary,
+      key = key, keys = keys).asInstanceOf[PouchDBAllDocsOptions]
+}
 
 @ScalaJSDefined
 trait PouchDBAllDocsResponse extends js.Object {
-
   val total_rows: Int
-
   val offset: Int
-
   val rows: js.Array[js.Dynamic]
-
 }
 
 @js.native
 trait EventEmitter extends js.Object {
-  def on(event: String, listener: js.Function1[js.Dynamic, Any]): this.type = js.native
-
+  def on(event: String, listener: js.Function0[Unit]): this.type = js.native
+  def on[A](event: String, listener: js.Function1[A, Unit]): this.type = js.native
 }
 
 @js.native
 trait ChangesEventEmitter extends EventEmitter {
-
   def cancel(): Unit = js.native
+}
+
+@js.native
+trait PouchDBError extends js.Object {
+  val status: Int = js.native
+  val name: String = js.native
+  val message: String = js.native
+}
+
+@js.native
+trait EventInfo extends js.Object {
+  val doc_write_failures: Int = js.native
+  val docs_read: Int = js.native
+  val docs_written: Int = js.native
+  val errors: js.Array[PouchDBError] = js.native
+  val last_seq: Int = js.native
+  val ok: Boolean = js.native
+  val start_time: String = js.native
+}
+
+@js.native
+trait OnChangeInfo extends EventInfo {
+  val docs: js.Array[js.Object] = js.native
+}
+
+@js.native
+trait OnCompleteInfo extends EventInfo {
+  val end_time: String = js.native
+  val status: String = js.native
 }
 
 object ChangesEventEmitter {
 
   implicit class ChangesEventEmitterEvents(val self: ChangesEventEmitter) extends AnyVal {
-    def onChange(listener: js.Function1[js.Dynamic, Any]): self.type = self.on("change", listener)
-
-    def onComplete(listener: js.Function1[js.Dynamic, Any]): self.type = self.on("complete", listener)
-
-    def onError(listener: js.Function1[js.Dynamic, Any]): self.type = self.on("error", listener)
-
-    def onCreate(listener: js.Function1[js.Dynamic, Any]): self.type = self.on("create", listener)
-
-    def onUpdate(listener: js.Function1[js.Dynamic, Any]): self.type = self.on("update", listener)
-
-    def onDelete(listener: js.Function1[js.Dynamic, Any]): self.type = self.on("delete", listener)
-
-    def onDenied(listener: js.Function1[js.Dynamic, Any]): self.type = self.on("denied", listener)
-
-    def onPaused(listener: js.Function1[js.Dynamic, Any]): self.type = self.on("paused", listener)
-
-    def onActive(listener: js.Function1[js.Dynamic, Any]): self.type = self.on("active", listener)
+    def onChange(listener: js.Function1[OnChangeInfo, Unit]): self.type = self.on("change", listener)
+    def onComplete(listener: js.Function1[OnCompleteInfo, Unit]): self.type = self.on("complete", listener)
+    def onError(listener: js.Function1[PouchDBError, Unit]): self.type = self.on("error", listener)
+    def onDenied(listener: js.Function1[PouchDBError, Unit]): self.type = self.on("denied", listener)
+    def onPaused(listener: js.Function1[PouchDBError, Unit]): self.type = self.on("paused", listener)
+    def onActive(listener: js.Function0[Unit]): self.type = self.on("active", listener)
+    def onCreated(listener: js.Function1[String, Unit]): self.type = self.on("created", listener)
+    def onDestroyed(listener: js.Function1[String, Unit]): self.type = self.on("destroyed", listener)
   }
 
 }
 
 @js.native
-class PouchDBChangesOptions(val live: UndefOr[Boolean] = undefined,
-                            val include_docs: UndefOr[Boolean] = undefined,
-                            val conflicts: UndefOr[Boolean] = undefined,
-                            val attachments: UndefOr[Boolean] = undefined,
-                            val binary: UndefOr[Boolean] = undefined,
-                            val descending: UndefOr[Boolean] = undefined,
-                            val since: UndefOr[String] = undefined,
-                            val limit: UndefOr[Int] = undefined,
-                            val timeout: UndefOr[Int] = undefined,
-                            val heartbeat: UndefOr[Int] = undefined,
-                            val filter: UndefOr[js.Function] = undefined,
-                            val doc_ids: UndefOr[js.Array[String]] = undefined,
-                            val query_params: UndefOr[js.Dynamic] = undefined,
-                            val view: UndefOr[js.Function] = undefined,
-                            val return_docs: UndefOr[Boolean] = undefined,
-                            val batch_size: UndefOr[Int] = undefined,
-                            val style: UndefOr[String] = undefined) extends js.Object
+trait PouchDBChangesOptions extends js.Object {
+  val live: UndefOr[Boolean] = js.native
+  val include_docs: UndefOr[Boolean] = js.native
+  val conflicts: UndefOr[Boolean] = js.native
+  val attachments: UndefOr[Boolean] = js.native
+  val binary: UndefOr[Boolean] = js.native
+  val descending: UndefOr[Boolean] = js.native
+  val since: UndefOr[String] = js.native
+  val limit: UndefOr[Int] = js.native
+  val timeout: UndefOr[Int] = js.native
+  val heartbeat: UndefOr[Int] = js.native
+  val filter: UndefOr[js.Function] = js.native
+  val doc_ids: UndefOr[js.Array[String]] = js.native
+  val query_params: UndefOr[js.Dynamic] = js.native
+  val view: UndefOr[js.Function] = js.native
+  val return_docs: UndefOr[Boolean] = js.native
+  val batch_size: UndefOr[Int] = js.native
+  val style: UndefOr[String] = js.native
+}
 
-
-@ScalaJSDefined
-class PouchDBReplicateOptions(val live: UndefOr[Boolean] = undefined,
-                              val retry: UndefOr[Boolean] = undefined,
-                              val filter: UndefOr[js.Function] = undefined,
-                              val doc_ids: UndefOr[js.Array[String]] = undefined,
-                              val query_params: UndefOr[js.Object] = undefined,
-                              val view: UndefOr[js.Function] = undefined,
-                              val since: UndefOr[String] = undefined,
-                              val heartbeat: UndefOr[Int] = undefined,
-                              val timeout: UndefOr[Int] = undefined,
-                              val batch_size: UndefOr[Int] = undefined,
-                              val batches_limit: UndefOr[Int] = undefined,
-                              val back_off_function: UndefOr[js.Function] = undefined) extends js.Object
-
-
-@js.native
-trait Replicate extends js.Object {
-  def to(remoteDB: String, options: PouchDBReplicateOptions = ???): ChangesEventEmitter = js.native
-
-  def from(remoteDB: String, options: PouchDBReplicateOptions = ???): ChangesEventEmitter = js.native
+object PouchDBChangesOptions {
+  def apply(live: UndefOr[Boolean] = undefined, include_docs: UndefOr[Boolean] = undefined, conflicts: UndefOr[Boolean] = undefined,
+            attachments: UndefOr[Boolean] = undefined, binary: UndefOr[Boolean] = undefined, descending: UndefOr[Boolean] = undefined,
+            since: UndefOr[String] = undefined, limit: UndefOr[Int] = undefined, timeout: UndefOr[Int] = undefined,
+            heartbeat: UndefOr[Int] = undefined, filter: UndefOr[js.Function] = undefined, doc_ids: UndefOr[js.Array[String]] = undefined,
+            query_params: UndefOr[js.Dynamic] = undefined, view: UndefOr[js.Function] = undefined, return_docs: UndefOr[Boolean] = undefined,
+            batch_size: UndefOr[Int] = undefined, style: UndefOr[String] = undefined): PouchDBChangesOptions =
+    js.Dynamic.literal(live = live, include_docs = include_docs, conflicts = conflicts, attachments = attachments,
+      binary = binary, descending = descending, since = since, limit = limit, timeout = timeout, heartbeat = heartbeat,
+      filter = filter, doc_ids = doc_ids, query_params = query_params, view = view, return_docs = return_docs,
+      batch_size = batch_size, style = style).asInstanceOf[PouchDBChangesOptions]
 }
 
 @js.native
-class PouchDBQueryOptions(val fun: UndefOr[js.Function] = undefined,
-                          val reduce: UndefOr[js.Function | String] = undefined,
-                          val include_docs: UndefOr[Boolean] = undefined,
-                          val startkey: UndefOr[String] = undefined,
-                          val endkey: UndefOr[String] = undefined,
-                          val inclusive_end: UndefOr[Boolean] = undefined,
-                          val limit: UndefOr[Int] = undefined,
-                          val skip: UndefOr[Int] = undefined,
-                          val descending: UndefOr[Boolean] = undefined,
-                          val key: UndefOr[String] = undefined,
-                          val keys: UndefOr[js.Array[String]] = undefined,
-                          val group: UndefOr[Boolean] = undefined,
-                          val group_level: UndefOr[Int] = undefined,
-                          val stale: UndefOr[String] = undefined) extends js.Object
+trait PouchDBReplicateOptions extends js.Object {
+  val live: UndefOr[Boolean] = js.native
+  val retry: UndefOr[Boolean] = js.native
+  val filter: UndefOr[js.Function] = js.native
+  val doc_ids: UndefOr[js.Array[String]] = js.native
+  val query_params: UndefOr[js.Object] = js.native
+  val view: UndefOr[js.Function] = js.native
+  val since: UndefOr[String] = js.native
+  val heartbeat: UndefOr[Int] = js.native
+  val timeout: UndefOr[Int] = js.native
+  val batch_size: UndefOr[Int] = js.native
+  val batches_limit: UndefOr[Int] = js.native
+  val back_off_function: UndefOr[js.Function] = js.native
+}
 
+object PouchDBReplicateOptions {
+  def apply(live: UndefOr[Boolean] = undefined, retry: UndefOr[Boolean] = undefined, filter: UndefOr[js.Function] = undefined,
+            doc_ids: UndefOr[js.Array[String]] = undefined, query_params: UndefOr[js.Object] = undefined,
+            view: UndefOr[js.Function] = undefined, since: UndefOr[String] = undefined, heartbeat: UndefOr[Int] = undefined,
+            timeout: UndefOr[Int] = undefined, batch_size: UndefOr[Int] = undefined, batches_limit: UndefOr[Int] = undefined,
+            back_off_function: UndefOr[js.Function] = undefined): PouchDBReplicateOptions =
+    js.Dynamic.literal(live = live, retry = retry, filter = filter, doc_ids = doc_ids, query_params = query_params,
+      view = view, since = since, heartbeat = heartbeat, timeout = timeout, batch_size = batch_size,
+      batches_limit = batches_limit, back_off_function = back_off_function).asInstanceOf[PouchDBReplicateOptions]
+}
+
+@js.native
+trait Replicate extends js.Object {
+  def to(remoteDB: PouchDB | String, options: PouchDBReplicateOptions = ???): ChangesEventEmitter = js.native
+
+  def from(remoteDB: PouchDB | String, options: PouchDBReplicateOptions = ???): ChangesEventEmitter = js.native
+}
+
+@js.native
+trait PouchDBQueryOptions extends js.Object {
+  val fun: UndefOr[js.Function] = js.native
+  val reduce: UndefOr[js.Function | String] = js.native
+  val include_docs: UndefOr[Boolean] = js.native
+  val startkey: UndefOr[String] = js.native
+  val endkey: UndefOr[String] = js.native
+  val inclusive_end: UndefOr[Boolean] = js.native
+  val limit: UndefOr[Int] = js.native
+  val skip: UndefOr[Int] = js.native
+  val descending: UndefOr[Boolean] = js.native
+  val key: UndefOr[String] = js.native
+  val keys: UndefOr[js.Array[String]] = js.native
+  val group: UndefOr[Boolean] = js.native
+  val group_level: UndefOr[Int] = js.native
+  val stale: UndefOr[String] = js.native
+}
+
+object PouchDBQueryOptions {
+  def apply(fun: UndefOr[js.Function] = undefined, reduce: UndefOr[js.Function | String] = undefined,
+            include_docs: UndefOr[Boolean] = undefined, startkey: UndefOr[String] = undefined,
+            endkey: UndefOr[String] = undefined, inclusive_end: UndefOr[Boolean] = undefined,
+            limit: UndefOr[Int] = undefined, skip: UndefOr[Int] = undefined, descending: UndefOr[Boolean] = undefined,
+            key: UndefOr[String] = undefined, keys: UndefOr[js.Array[String]] = undefined,
+            group: UndefOr[Boolean] = undefined, group_level: UndefOr[Int] = undefined,
+            stale: UndefOr[String] = undefined): PouchDBQueryOptions =
+    js.Dynamic.literal(fun = fun, reduce = reduce.asInstanceOf[js.Any], include_docs = include_docs, startkey = startkey, endkey = endkey,
+      inclusive_end = inclusive_end, limit = limit, skip = skip, descending = descending, key = key, keys = keys,
+      group = group, group_level = group_level, stale = stale).asInstanceOf[PouchDBQueryOptions]
+}
 
 @js.native
 trait PouchDBDebug extends js.Object {
   def enable(to: String = "*"): Unit = js.native
 
   def disable(): Unit = js.native
-
 }
 
-@ScalaJSDefined
-class PouchDBGetOptions(val rev: UndefOr[String] = undefined,
-                        val revs: UndefOr[Boolean] = undefined,
-                        val revs_info: UndefOr[Boolean] = undefined,
-                        val open_revs: UndefOr[js.Dynamic] = undefined,
-                        val conflicts: UndefOr[Boolean] = undefined,
-                        val attachments: UndefOr[Boolean] = undefined,
-                        val ajax: UndefOr[PouchDBAjaxOptions] = undefined) extends js.Object
+@js.native
+class PouchDBGetOptions extends js.Object {
+  val rev: UndefOr[String] = js.native
+  val revs: UndefOr[Boolean] = js.native
+  val revs_info: UndefOr[Boolean] = js.native
+  val open_revs: UndefOr[js.Dynamic] = js.native
+  val conflicts: UndefOr[Boolean] = js.native
+  val attachments: UndefOr[Boolean] = js.native
+  val ajax: UndefOr[PouchDBAjaxOptions] = js.native
+}
 
-
+object PouchDBGetOptions {
+  def apply(rev: UndefOr[String] = undefined, revs: UndefOr[Boolean] = undefined, revs_info: UndefOr[Boolean] = undefined,
+            open_revs: UndefOr[js.Dynamic] = undefined, conflicts: UndefOr[Boolean] = undefined, attachments: UndefOr[Boolean] = undefined,
+            ajax: UndefOr[PouchDBAjaxOptions] = undefined): PouchDBGetOptions =
+    js.Dynamic.literal(rev = rev, revs = revs, revs_info = revs_info, open_revs = open_revs, conflicts = conflicts,
+      attachments = attachments, ajax = ajax).asInstanceOf[PouchDBGetOptions]
+}
 
 @ScalaJSDefined
 trait PouchDBInfo extends js.Object {
@@ -184,31 +292,44 @@ trait PouchDBInfo extends js.Object {
 
 @ScalaJSDefined
 trait PouchDBUpdateDocResponse extends js.Object {
-  val ok : Boolean
-  val id : String
-  val rev : String
+  val ok: Boolean
+  val id: String
+  val rev: String
 }
 
 @ScalaJSDefined
 trait PouchDBEntity extends js.Object {
-  val _id : String
-  val _rev : String
+  val _id: String
+  val _rev: String
 }
 
-@ScalaJSDefined
-class PouchDBCompactOptions(val interval: UndefOr[Int] = undefined) extends js.Object
+@js.native
+trait PouchDBCompactOptions extends js.Object {
+  val interval: UndefOr[Int] = js.native
+}
 
-@ScalaJSDefined
-class PouchDBBulkGetOptions(val docs: js.Array[js.Object],
-                            val revs: UndefOr[Boolean] = undefined,
-                            val attachments: UndefOr[Boolean] = undefined,
-                            val binary: UndefOr[Boolean] = undefined) extends js.Object
+object PouchDBCompactOptions {
+  def apply(interval: UndefOr[Int] = undefined): PouchDBCompactOptions =
+    js.Dynamic.literal(interval = interval).asInstanceOf[PouchDBCompactOptions]
+}
 
-case class PouchDBException(err: js.Dynamic) extends Exception
+@js.native
+trait PouchDBBulkGetOptions extends js.Object {
+  val docs: js.Array[js.Object] = js.native
+  val revs: UndefOr[Boolean] = js.native
+  val attachments: UndefOr[Boolean] = js.native
+  val binary: UndefOr[Boolean] = js.native
+}
+
+object PouchDBBulkGetOptions {
+  def apply(docs: js.Array[js.Object], revs: UndefOr[Boolean] = undefined, attachments: UndefOr[Boolean] = undefined,
+            binary: UndefOr[Boolean] = undefined): PouchDBBulkGetOptions =
+    js.Dynamic.literal(docs = docs, revs = revs, attachments = attachments, binary = binary).asInstanceOf[PouchDBBulkGetOptions]
+}
 
 @js.native
 @JSName("PouchDB")
-class PouchDB(name: String = ???, options: PouchDBOptions = ???) extends js.Object with PouchDBFindPlugin{
+class PouchDB(name: String = ???, options: PouchDBOptions | js.Dynamic | js.Object | js.Dictionary[Any] = ???) extends js.Object with PouchDBFindPlugin {
 
   var _db_name: String = js.native
 
@@ -220,10 +341,13 @@ class PouchDB(name: String = ???, options: PouchDBOptions = ???) extends js.Obje
 
   def get[T <: js.Object](docId: String, options: PouchDBGetOptions = ???): Promise[T] = js.native
 
-  def remove(doc: js.Object, options: js.Dynamic = ???): Promise[PouchDBUpdateDocResponse] = js.native
+  def remove(doc: js.Object): Promise[PouchDBUpdateDocResponse] = js.native
 
-  @JSName("remove")
-  def removeWithId(docId: String, docRev: String, options: js.Dynamic = ???): Promise[js.Dynamic] = js.native
+  def remove(doc: js.Object, options: js.Dynamic): Promise[PouchDBUpdateDocResponse] = js.native
+
+  def remove(docId: String, docRev: String): Promise[PouchDBUpdateDocResponse] = js.native
+
+  def remove(docId: String, docRev: String, options: js.Dynamic): Promise[PouchDBUpdateDocResponse] = js.native
 
   def bulkDocs(docs: js.Array[js.Object], options: js.Dynamic = ???): Promise[js.Dynamic] = js.native
 
@@ -268,6 +392,8 @@ object PouchDB extends EventEmitter {
   def plugin(plugins: js.Dynamic): Unit = js.native
 
   val debug: PouchDBDebug = js.native
+
+  val version: String = js.native
 
 }
 

--- a/src/main/scala/chandu0101/pouchdb/PouchDB.scala
+++ b/src/main/scala/chandu0101/pouchdb/PouchDB.scala
@@ -145,7 +145,7 @@ object ChangesEventEmitter {
     def onComplete(listener: js.Function1[OnCompleteInfo, Unit]): self.type = self.on("complete", listener)
     def onError(listener: js.Function1[PouchDBError, Unit]): self.type = self.on("error", listener)
     def onDenied(listener: js.Function1[PouchDBError, Unit]): self.type = self.on("denied", listener)
-    def onPaused(listener: js.Function1[PouchDBError, Unit]): self.type = self.on("paused", listener)
+    def onPaused(listener: js.Function1[UndefOr[PouchDBError], Unit]): self.type = self.on("paused", listener)
     def onActive(listener: js.Function0[Unit]): self.type = self.on("active", listener)
     def onCreated(listener: js.Function1[String, Unit]): self.type = self.on("created", listener)
     def onDestroyed(listener: js.Function1[String, Unit]): self.type = self.on("destroyed", listener)

--- a/src/test/resources/test-bundle.js
+++ b/src/test/resources/test-bundle.js
@@ -10528,7 +10528,7 @@
 	PouchDB.Errors = allErrors;
 	PouchDB.replicate = replication.replicate;
 	PouchDB.sync = sync;
-	PouchDB.version = '5.3.1'; // will be automatically supplied by build.sh
+	PouchDB.version = '5.4.5'; // will be automatically supplied by build.sh
 	PouchDB.adapter('http', HttpPouch);
 	PouchDB.adapter('https', HttpPouch);
 


### PR DESCRIPTION
- Update PouchDB version to 5.4.5 and Scala.js to 0.6.11.
- Contemplate https://github.com/pouchdb/pouchdb/issues/5508 where PouchDB is stated to officially not support classes as options. This is done by changing classes to traits and providing constructors in companion objects' `apply` methods. This is a breaking change since the `new` keyword is no longer required to instantiate option types, but I think it is worth it.
- Types for PouchDBError and event parameters.
- Allow multiple types in several methods' parameters.
